### PR TITLE
Feature/process definition key

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.digitalstate.camunda.prometheus</groupId>
     <artifactId>camunda-prometheus-process-engine-plugin</artifactId>
-    <version>v1.8.0</version>
+    <version>1.9.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Camunda Prometheus Process Engine Plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.digitalstate.camunda.prometheus</groupId>
     <artifactId>camunda-prometheus-process-engine-plugin</artifactId>
-    <version>1.9.0-SNAPSHOT</version>
+    <version>v1.9.0</version>
     <packaging>jar</packaging>
 
     <name>Camunda Prometheus Process Engine Plugin</name>

--- a/src/main/java/io/digitalstate/camunda/prometheus/executionlisteners/ProcessDurationExecutionListener.java
+++ b/src/main/java/io/digitalstate/camunda/prometheus/executionlisteners/ProcessDurationExecutionListener.java
@@ -22,6 +22,7 @@ public class ProcessDurationExecutionListener implements ExecutionListener {
 
     private List<String> histogramLabelNames = Arrays.asList("engine_name",
                                                             "process_definition_id",
+                                                            "process_definition_key",
                                                             "deployment_id",
                                                             "process_definition_version",
                                                             "process_definition_version_tag");
@@ -39,6 +40,7 @@ public class ProcessDurationExecutionListener implements ExecutionListener {
 
         ProcessDefinition processDefinition = execution.getProcessEngineServices()
                 .getRepositoryService().getProcessDefinition(processDefinitionId);
+        final String processDefinitionKey = processDefinition.getKey();
         String processDefinitionVersion = String.valueOf(processDefinition.getVersion());
         String deploymentId = processDefinition.getDeploymentId();
         String processDefinitionVersionTag = processDefinition.getVersionTag() == null ? "" : processDefinition.getVersionTag();
@@ -72,6 +74,7 @@ public class ProcessDurationExecutionListener implements ExecutionListener {
                         // set the histogram with the duration from the activity instance
                         histogramMetric.observeValue(durationInSeconds, Arrays.asList(promClean(engineName),
                                                                                     promClean(processDefinitionId),
+                                                                                    promClean(processDefinitionKey),
                                                                                     promClean(deploymentId),
                                                                                     promClean(processDefinitionVersion),
                                                                                     promClean(processDefinitionVersionTag)));


### PR DESCRIPTION
Hello,
this small feature adds the process-definition-key to the tags camunda_process_instance_duration historic metric. 
The key helps a lot to group multiple process definition statistics in metric dashboards.
best,
Guido